### PR TITLE
fix localhost problem on ubuntu

### DIFF
--- a/src/main/java/co/paralleluniverse/galaxy/netty/AbstractTcpClient.java
+++ b/src/main/java/co/paralleluniverse/galaxy/netty/AbstractTcpClient.java
@@ -24,6 +24,7 @@ import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Deque;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutorService;
@@ -120,6 +121,7 @@ abstract class AbstractTcpClient extends ClusterService {
             }
         });
 
+        bootstrap.setOption("localAddress", new InetSocketAddress(InetAddress.getLocalHost(), 0));
         bootstrap.setOption("tcpNoDelay", true);
         bootstrap.setOption("keepAlive", true);
 

--- a/src/main/java/co/paralleluniverse/galaxy/netty/UDPComm.java
+++ b/src/main/java/co/paralleluniverse/galaxy/netty/UDPComm.java
@@ -311,7 +311,7 @@ public class UDPComm extends AbstractComm<InetSocketAddress> {
             }
         });
 
-        bootstrap.setOption("localAddress", new InetSocketAddress(port));
+        bootstrap.setOption("localAddress", new InetSocketAddress(InetAddress.getLocalHost(), port));
         bootstrap.setOption("tcpNoDelay", true);
 
         monitor.registerMBean();


### PR DESCRIPTION
If run server and peer on one PC, has resolve problem.

Hosts:
/etc/hosts
127.0.0.1	localhost
127.0.1.1	linux

Stacktrace:
[Server:err] 6652: [06-10 12:16:51,105] New I/O worker #6 ERROR ChannelNodeNameReader : Channel coming from /127.0.0.1:58871 claims to be node NODE node-0000000002 id: 1 ip_addr: /127.0.1.1 - host address mismatch! at .(ChannelNodeNameReader.java:64)
    [Server:err] 6653: [06-10 12:16:51,105] New I/O worker #6 WARN  comm : Exception caught in channel [id: 0xc825434e, /127.0.0.1:58871 => /127.0.1.1:9675]:  java.lang.RuntimeException Node identity problem! at .(LoggingHandler.java:54)
    [Server:err] 6654: java.lang.RuntimeException: Node identity problem!
    [Server:err] 6655: 	at co.paralleluniverse.galaxy.netty.ChannelNodeNameReader.messageReceived(ChannelNodeNameReader.java:65)
    [Server:err] 6656: 	at org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:296)
    [Server:err] 6657: 	at org.jboss.netty.handler.codec.frame.FrameDecoder.unfoldAndFireMessageReceived(FrameDecoder.java:462)
    [Server:err] 6658: 	at org.jboss.netty.handler.codec.frame.FrameDecoder.callDecode(FrameDecoder.java:443)
    [Server:err] 6659: 	at org.jboss.netty.handler.codec.frame.FrameDecoder.messageReceived(FrameDecoder.java:303)
    [Server:err] 6660: 	at org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:268)
    [Server:err] 6661: 	at org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:255)
    [Server:err] 6662: 	at org.jboss.netty.channel.socket.nio.NioWorker.read(NioWorker.java:88)
    [Server:err] 6663: 	at org.jboss.netty.channel.socket.nio.AbstractNioWorker.process(AbstractNioWorker.java:108)
    [Server:err] 6664: 	at org.jboss.netty.channel.socket.nio.AbstractNioSelector.run(AbstractNioSelector.java:318)
    [Server:err] 6665: 	at org.jboss.netty.channel.socket.nio.AbstractNioWorker.run(AbstractNioWorker.java:89)
    [Server:err] 6666: 	at org.jboss.netty.channel.socket.nio.NioWorker.run(NioWorker.java:178)
    [Server:err] 6667: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    [Server:err] 6668: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    [Server:err] 6669: 	at java.lang.Thread.run(Thread.java:744)