### PR TITLE
make cluster shutdown more graceful

### DIFF
--- a/src/main/java/co/paralleluniverse/galaxy/cluster/DistributedTree.java
+++ b/src/main/java/co/paralleluniverse/galaxy/cluster/DistributedTree.java
@@ -112,7 +112,12 @@ public interface DistributedTree {
      * @param out The output stream to which the tree structure is to be sent.
      */
     void print(String node, java.io.PrintStream out);
-    
+
+    /**
+     * Method is called when Galaxy Cluster is going offline and requests all services to shutdown.
+     */
+    void shutdown();
+
     /**
      * A listener for DistributedTree node events.
      */

--- a/src/main/java/co/paralleluniverse/galaxy/cluster/DistributedTreeAdapter.java
+++ b/src/main/java/co/paralleluniverse/galaxy/cluster/DistributedTreeAdapter.java
@@ -79,4 +79,9 @@ public class DistributedTreeAdapter implements DistributedTree {
     public void print(String node, java.io.PrintStream out) {
         tree.print(node, out);
     }
+
+    @Override
+    public void shutdown() {
+        tree.shutdown();
+    }
 }

--- a/src/main/java/co/paralleluniverse/galaxy/core/AbstractCluster.java
+++ b/src/main/java/co/paralleluniverse/galaxy/core/AbstractCluster.java
@@ -323,6 +323,7 @@ public abstract class AbstractCluster extends Service implements Cluster {
 
     @Override
     public void shutdown() {
+        controlTree.shutdown();
 // moved to setOnline(false)
 //        if (myNodeInfo.getName() != null) {
 //            controlTree.delete(LEADERS + "/" + myNodeInfo.getName());

--- a/src/main/java/co/paralleluniverse/galaxy/core/AbstractComm.java
+++ b/src/main/java/co/paralleluniverse/galaxy/core/AbstractComm.java
@@ -165,4 +165,10 @@ public abstract class AbstractComm<Address> extends ClusterService implements Co
     @Override
     public void nodeRemoved(short id) {
     }
+
+    @Override
+    protected void shutdown() {
+        super.shutdown();
+        scheduler.shutdownNow();
+    }
 }

--- a/src/main/java/co/paralleluniverse/galaxy/jgroups/DistributedTreeAdapter.java
+++ b/src/main/java/co/paralleluniverse/galaxy/jgroups/DistributedTreeAdapter.java
@@ -90,6 +90,10 @@ class DistributedTreeAdapter implements DistributedTree {
         out.println(tree.toString(node));
     }
 
+    @Override
+    public void shutdown() {
+    }
+
     private static class ListenerAdapter implements ReplicatedTreeListener {
         private final Listener listener;
 

--- a/src/main/java/co/paralleluniverse/galaxy/netty/UDPComm.java
+++ b/src/main/java/co/paralleluniverse/galaxy/netty/UDPComm.java
@@ -357,6 +357,7 @@ public class UDPComm extends AbstractComm<InetSocketAddress> {
 
     @Override
     public void shutdown() {
+        super.shutdown();
         LOG.info("Shutting down.");
         monitor.unregisterMBean();
         if (channel != null)

--- a/src/test/java/co/paralleluniverse/galaxy/core/LocalTree.java
+++ b/src/test/java/co/paralleluniverse/galaxy/core/LocalTree.java
@@ -20,7 +20,6 @@
 package co.paralleluniverse.galaxy.core;
 
 import co.paralleluniverse.galaxy.cluster.DistributedTree;
-import co.paralleluniverse.galaxy.cluster.DistributedTree.Listener;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -218,6 +217,10 @@ public class LocalTree implements DistributedTree {
             return null;
         final String child = fqn.substring(index + 1, fqn.length());
         return child;
+    }
+
+    @Override
+    public void shutdown() {
     }
 
     private class Node {


### PR DESCRIPTION
There were 2 problems:
 * **co.paralleluniverse.galaxy.core.AbstractComm#scheduler** was hanging with NON-daemon thread when galaxy cluster goes offline
 * the second one is described in javadoc on added field **co.paralleluniverse.galaxy.zookeeper.ZooKeeperDistributedTree#shutdownRequested**