### PR TITLE
Jetty thread pool configurations and thread naming strategy were ignored. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile ("com.codahale.metrics:metrics-core:3.0.2") {
         exclude group: "org.slf4j", module: '*'
     }
-    compile "io.netty:netty:3.9.4.Final"
+    compile "io.netty:netty:3.10.4.Final"
     compile "org.jgroups:jgroups:3.6.0.Final"
     compile "com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4"
     compile "com.sleepycat:je:5.0.73"

--- a/src/main/java/co/paralleluniverse/galaxy/netty/AbstractTcpClient.java
+++ b/src/main/java/co/paralleluniverse/galaxy/netty/AbstractTcpClient.java
@@ -13,7 +13,6 @@
  */
 package co.paralleluniverse.galaxy.netty;
 
-import static co.paralleluniverse.common.collection.Util.reverse;
 import co.paralleluniverse.common.monitoring.ThreadPoolExecutorMonitor;
 import co.paralleluniverse.galaxy.Cluster;
 import co.paralleluniverse.galaxy.cluster.NodeInfo;
@@ -22,38 +21,24 @@ import co.paralleluniverse.galaxy.core.CommThread;
 import co.paralleluniverse.galaxy.core.Message;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.util.Deque;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import org.jboss.netty.bootstrap.ClientBootstrap;
-import org.jboss.netty.channel.Channel;
-import org.jboss.netty.channel.ChannelException;
-import org.jboss.netty.channel.ChannelFactory;
-import org.jboss.netty.channel.ChannelFuture;
-import org.jboss.netty.channel.ChannelHandler;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.channel.ChannelPipelineFactory;
-import org.jboss.netty.channel.ChannelStateEvent;
-import org.jboss.netty.channel.ExceptionEvent;
-import org.jboss.netty.channel.MessageEvent;
-import org.jboss.netty.channel.SimpleChannelHandler;
-import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+import org.jboss.netty.channel.*;
 import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;
 import org.jboss.netty.handler.execution.OrderedMemoryAwareThreadPoolExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Deque;
+import java.util.concurrent.*;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static co.paralleluniverse.common.collection.Util.reverse;
+
 /**
- *
  * @author pron
  */
 abstract class AbstractTcpClient extends ClusterService {
@@ -62,9 +47,9 @@ abstract class AbstractTcpClient extends ClusterService {
     private String nodeName;
     private final String portProperty;
     private InetSocketAddress address;
-    private final ChannelPipelineFactory origChannelFacotry;
-    private final ChannelFactory channelFactory;
-    private final ClientBootstrap bootstrap;
+    private ChannelPipelineFactory origChannelFacotry;
+    private ChannelFactory channelFactory;
+    private ClientBootstrap bootstrap;
     private boolean connecting;
     private Channel channel;
     private volatile boolean reconnect;
@@ -76,24 +61,31 @@ abstract class AbstractTcpClient extends ClusterService {
     private ThreadPoolExecutor workerExecutor;
     private OrderedMemoryAwareThreadPoolExecutor receiveExecutor;
 
+
     public AbstractTcpClient(String name, final Cluster cluster, final String portProperty) throws Exception {
         super(name, cluster);
-
         this.portProperty = portProperty;
+        reconnect = true;
+    }
 
+    @Override
+    protected void init() throws Exception {
+        super.init();
         if (bossExecutor == null)
             bossExecutor = (ThreadPoolExecutor) Executors.newCachedThreadPool();
         if (workerExecutor == null)
             workerExecutor = (ThreadPoolExecutor) Executors.newCachedThreadPool();
-        configureThreadPool(name + "-tcpClientBoss", bossExecutor);
-        configureThreadPool(name + "-tcpClientWorker", workerExecutor);
+        configureThreadPool(getName() + "-tcpClientBoss", bossExecutor);
+        configureThreadPool(getName() + "-tcpClientWorker", workerExecutor);
         if (receiveExecutor != null)
-            configureThreadPool(name + "-tcpClientReceive", receiveExecutor);
+            configureThreadPool(getName() + "-tcpClientReceive", receiveExecutor);
 
-        this.channelFactory = new NioClientSocketChannelFactory(bossExecutor, workerExecutor);
+        this.channelFactory = new NioClientSocketChannelFactory(bossExecutor, workerExecutor,
+                NettyUtils.getWorkerCount(workerExecutor));
         this.bootstrap = new ClientBootstrap(channelFactory);
 
-        origChannelFacotry = new TcpMessagePipelineFactory(LOG, null, receiveExecutor) {
+        final Cluster cluster = getCluster();
+        this.origChannelFacotry = new TcpMessagePipelineFactory(LOG, null, receiveExecutor) {
             @Override
             public ChannelPipeline getPipeline() throws Exception {
                 final ChannelPipeline pipeline = super.getPipeline();
@@ -122,8 +114,6 @@ abstract class AbstractTcpClient extends ClusterService {
 
         bootstrap.setOption("tcpNoDelay", true);
         bootstrap.setOption("keepAlive", true);
-
-        reconnect = true;
     }
 
     @Override
@@ -230,7 +220,7 @@ abstract class AbstractTcpClient extends ClusterService {
 
     private void connect() {
         try {
-            for (;;) {
+            for (; ; ) {
                 channelLock.lock();
                 try {
                     if (!reconnect || Thread.interrupted())
@@ -322,6 +312,7 @@ abstract class AbstractTcpClient extends ClusterService {
     }
 
     abstract protected void receive(ChannelHandlerContext ctx, Message message);
+
     private final ChannelHandler channelHandler = new SimpleChannelHandler() {
         @Override
         public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) {

--- a/src/main/java/co/paralleluniverse/galaxy/netty/AbstractTcpServer.java
+++ b/src/main/java/co/paralleluniverse/galaxy/netty/AbstractTcpServer.java
@@ -19,11 +19,13 @@ import co.paralleluniverse.galaxy.core.ClusterService;
 import co.paralleluniverse.galaxy.core.CommThread;
 import co.paralleluniverse.galaxy.core.Message;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import java.net.InetSocketAddress;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicLong;
+
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelFactory;
@@ -42,18 +44,18 @@ import org.slf4j.LoggerFactory;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 
 /**
- *
  * @author pron
  */
 public abstract class AbstractTcpServer extends ClusterService {
     private final Logger LOG = LoggerFactory.getLogger(AbstractTcpServer.class.getName() + "." + getName());
     //
     private final int port;
-    private final ChannelFactory channelFactory;
-    private final ServerBootstrap bootstrap;
+    private ChannelFactory channelFactory;
+    private ServerBootstrap bootstrap;
     private final DefaultChannelGroup channels;
     private final AtomicLong nextMessageId = new AtomicLong(1L);
-    private final ChannelPipelineFactory origChannelFacotry;
+    private ChannelPipelineFactory origChannelFacotry;
+    private final ChannelHandler testHandler;
     private ThreadPoolExecutor bossExecutor;
     private ThreadPoolExecutor workerExecutor;
     private OrderedMemoryAwareThreadPoolExecutor receiveExecutor;
@@ -62,24 +64,33 @@ public abstract class AbstractTcpServer extends ClusterService {
         super(name, cluster);
         this.channels = channels;
         this.port = port;
+        this.testHandler = testHandler;
+    }
 
+    public AbstractTcpServer(String name, Cluster cluster, DefaultChannelGroup channels, int port) {
+        this(name, cluster, channels, port, null);
+    }
+
+    @Override
+    protected void init() throws Exception {
+        super.init();
         if (bossExecutor == null)
             bossExecutor = (ThreadPoolExecutor) Executors.newCachedThreadPool();
         if (workerExecutor == null)
             workerExecutor = (ThreadPoolExecutor) Executors.newCachedThreadPool();
-        configureThreadPool(name + "-tcpServerBoss", bossExecutor);
-        configureThreadPool(name + "-tcpServerWorker", workerExecutor);
+        configureThreadPool(getName() + "-tcpServerBoss", bossExecutor);
+        configureThreadPool(getName() + "-tcpServerWorker", workerExecutor);
         if (receiveExecutor != null)
-            configureThreadPool(name + "-tcpServerReceive", receiveExecutor);
+            configureThreadPool(getName() + "-tcpServerReceive", receiveExecutor);
 
-        this.channelFactory = new NioServerSocketChannelFactory(bossExecutor, workerExecutor);
-        this.bootstrap = new ServerBootstrap(channelFactory);
+        channelFactory = new NioServerSocketChannelFactory(bossExecutor, workerExecutor);
+        bootstrap = new ServerBootstrap(channelFactory);
 
         origChannelFacotry = new TcpMessagePipelineFactory(LOG, channels, receiveExecutor) {
             @Override
             public ChannelPipeline getPipeline() throws Exception {
                 final ChannelPipeline pipeline = super.getPipeline();
-                pipeline.addBefore("messageCodec", "nodeNameReader", new ChannelNodeNameReader(cluster));
+                pipeline.addBefore("messageCodec", "nodeNameReader", new ChannelNodeNameReader(getCluster()));
                 pipeline.addLast("router", channelHandler);
                 if (testHandler != null)
                     pipeline.addLast("test", testHandler);
@@ -98,10 +109,6 @@ public abstract class AbstractTcpServer extends ClusterService {
         bootstrap.setOption("reuseAddress", true);
         bootstrap.setOption("child.tcpNoDelay", true);
         bootstrap.setOption("child.keepAlive", true);
-    }
-
-    public AbstractTcpServer(String name, Cluster cluster, DefaultChannelGroup channels, int port) {
-        this(name, cluster, channels, port, null);
     }
 
     public void setBossExecutor(ThreadPoolExecutor bossExecutor) {
@@ -129,6 +136,7 @@ public abstract class AbstractTcpServer extends ClusterService {
         }).build());
         ThreadPoolExecutorMonitor.register(name, executor);
     }
+
     private final ChannelHandler channelHandler = new SimpleChannelHandler() {
         @Override
         public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) {

--- a/src/main/java/co/paralleluniverse/galaxy/netty/NettyUtils.java
+++ b/src/main/java/co/paralleluniverse/galaxy/netty/NettyUtils.java
@@ -1,5 +1,7 @@
 package co.paralleluniverse.galaxy.netty;
 
+import org.jboss.netty.util.ThreadNameDeterminer;
+
 import java.util.concurrent.ThreadPoolExecutor;
 
 /**
@@ -12,6 +14,17 @@ public class NettyUtils {
      * Copy of {@link org.jboss.netty.channel.socket.nio.SelectorUtil#DEFAULT_IO_THREADS}
      */
     public static final int DEFAULT_IO_THREADS = Runtime.getRuntime().availableProcessors() * 2;
+    /**
+     * Copy of {@link org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory#DEFAULT_BOSS_COUNT}
+     */
+    public static final int DEFAULT_BOSS_COUNT = 1;
+
+    public static final ThreadNameDeterminer KEEP_UNCHANGED_DETERMINER = new ThreadNameDeterminer() {
+        @Override
+        public String determineThreadName(String currentThreadName, String proposedThreadName) throws Exception {
+            return currentThreadName;
+        }
+    };
 
     public static int getWorkerCount(ThreadPoolExecutor workerExecutor) {
         return Math.min(workerExecutor.getMaximumPoolSize(), DEFAULT_IO_THREADS);

--- a/src/main/java/co/paralleluniverse/galaxy/netty/NettyUtils.java
+++ b/src/main/java/co/paralleluniverse/galaxy/netty/NettyUtils.java
@@ -1,0 +1,19 @@
+package co.paralleluniverse.galaxy.netty;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Some constants used for configuring netty thread pools.
+ *
+ * @author s.stupin
+ */
+public class NettyUtils {
+    /**
+     * Copy of {@link org.jboss.netty.channel.socket.nio.SelectorUtil#DEFAULT_IO_THREADS}
+     */
+    public static final int DEFAULT_IO_THREADS = Runtime.getRuntime().availableProcessors() * 2;
+
+    public static int getWorkerCount(ThreadPoolExecutor workerExecutor) {
+        return Math.min(workerExecutor.getMaximumPoolSize(), DEFAULT_IO_THREADS);
+    }
+}

--- a/src/main/java/co/paralleluniverse/galaxy/netty/UDPComm.java
+++ b/src/main/java/co/paralleluniverse/galaxy/netty/UDPComm.java
@@ -276,13 +276,17 @@ public class UDPComm extends AbstractComm<InetSocketAddress> {
         }
 
         this.myAddress = new InetSocketAddress(InetAddress.getLocalHost(), port);
+        if (workerExecutor == null)
+            workerExecutor = (ThreadPoolExecutor) Executors.newCachedThreadPool();
 
         configureThreadPool(getWorkerExecutorName(), workerExecutor);
 
         if (receiveExecutor != null)
             configureThreadPool(getReceiveExecutorName(), receiveExecutor);
 
-        this.channelFactory = isSendToServerInsteadOfMulticast() ? new NioDatagramChannelFactory(workerExecutor) : new OioDatagramChannelFactory(workerExecutor);
+        this.channelFactory = isSendToServerInsteadOfMulticast()
+                ? new NioDatagramChannelFactory(workerExecutor, NettyUtils.getWorkerCount(workerExecutor))
+                : new OioDatagramChannelFactory(workerExecutor);
         this.bootstrap = new ConnectionlessBootstrap(channelFactory);
         this.bootstrap.setOption("receiveBufferSizePredictorFactory", new FixedReceiveBufferSizePredictorFactory(4096));
 

--- a/src/main/java/co/paralleluniverse/galaxy/netty/UDPComm.java
+++ b/src/main/java/co/paralleluniverse/galaxy/netty/UDPComm.java
@@ -279,6 +279,9 @@ public class UDPComm extends AbstractComm<InetSocketAddress> {
         if (workerExecutor == null)
             workerExecutor = (ThreadPoolExecutor) Executors.newCachedThreadPool();
 
+        // Netty ignores executor thread naming strategy cause of Worker renaming policy.
+        // org.jboss.netty.channel.socket.nio.AbstractNioWorker.newThreadRenamingRunnable()
+        // And unfortunately for NioDatagramChannelFactory itsn't possible to pass our own ThreadNameDeterminer.
         configureThreadPool(getWorkerExecutorName(), workerExecutor);
 
         if (receiveExecutor != null)

--- a/src/test/resources/config/_with_server.xml
+++ b/src/test/resources/config/_with_server.xml
@@ -34,14 +34,14 @@
         <property name="maxQueueSize" value="10"/>
         <property name="maxPacketSize" value="2048"/>
         <property name="maxRequestOnlyPacketSize" value="400"/>
-        <property name="workerExecutor">
-            <bean class="co.paralleluniverse.galaxy.core.ConfigurableThreadPool">
-                <constructor-arg name="corePoolSize" value="2"/>
-                <constructor-arg name="maximumPoolSize" value="8"/>
-                <constructor-arg name="keepAliveMillis" value="5000"/>
-                <constructor-arg name="maxQueueSize" value="500"/>
-            </bean>
-        </property>
+        <!--<property name="workerExecutor">-->
+            <!--<bean class="co.paralleluniverse.galaxy.core.ConfigurableThreadPool">-->
+                <!--<constructor-arg name="corePoolSize" value="2"/>-->
+                <!--<constructor-arg name="maximumPoolSize" value="8"/>-->
+                <!--<constructor-arg name="keepAliveMillis" value="5000"/>-->
+                <!--<constructor-arg name="maxQueueSize" value="500"/>-->
+            <!--</bean>-->
+        <!--</property>-->
         <property name="receiveExecutor">
             <bean class="org.jboss.netty.handler.execution.OrderedMemoryAwareThreadPoolExecutor">
                 <constructor-arg index="0" value="8"/> <!-- name="corePoolSize" -->


### PR DESCRIPTION
The main problem was that **co.paralleluniverse.galaxy.netty.AbstractTcpServer#channelFactory** was initialized during consturctor and any subsequent changes to **workerExecutor** were simply ignored. So when Spring bean iniitalizer calls **setWorkerExecutor** it doesn't make sense.