### PR TITLE
Closing BerkeleyDB resources, make handling TcpClient channels failings and disconnects identical

### DIFF
--- a/src/main/java/co/paralleluniverse/galaxy/berkeleydb/BerkeleyDB.java
+++ b/src/main/java/co/paralleluniverse/galaxy/berkeleydb/BerkeleyDB.java
@@ -386,6 +386,7 @@ public class BerkeleyDB extends Component implements MainMemoryDB {
         ownerIndex.close();
         ownerDirectory.close();
         mainStore.close();
+        allocationDirectory.close();
         env.close();
     }
 

--- a/src/main/java/co/paralleluniverse/galaxy/netty/TcpServerServerComm.java
+++ b/src/main/java/co/paralleluniverse/galaxy/netty/TcpServerServerComm.java
@@ -136,7 +136,8 @@ final class TcpServerServerComm extends AbstractTcpServer implements Comm {
                 }
                 final short nodeId = node.getNodeId();
                 if (channels.containsKey(nodeId)) {
-                    LOG.warn("Received connection from address {} of node {}, but this node is already connected.", channel.getRemoteAddress(), nodeId);
+                    LOG.warn("Received connection from address {} of node {}, but this node is already connected from address {}.",
+                            channel.getRemoteAddress(), nodeId, channels.get(nodeId).getRemoteAddress());
                     throw new RuntimeException("Node " + nodeId + " already connected.");
                 }
                 final boolean added = super.add(channel);


### PR DESCRIPTION
Hello,
prior to this changes any error in TcpClient channel leads to setting Component in an unavailable state no matter what channel fails. That was not totally correct cause we have to check only the main channel (**co.paralleluniverse.galaxy.netty.AbstractTcpClient#channel**) when calling **setReady(false)** on this component.